### PR TITLE
Fix rotation issue where all users disappear when repeatedly clicking Next

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1301,23 +1301,50 @@
                 return;
             }
             
+            // キューが空の場合はチェック
+            if (appState.queue.length === 0) {
+                alert('キューにユーザーがいないため、交代できません');
+                return;
+            }
+            
             const rotationAmount = Math.min(appState.rotationCount, rotatableUsers.length);
             const rotatingUsers = rotatableUsers.slice(0, rotationAmount);
             
-            console.log('🔄 Rotating users:', rotatingUsers);
+            // 交代可能なキューのユーザー数をチェック
+            const availableReplacements = Math.min(appState.queue.length, rotatingUsers.length);
+            if (availableReplacements === 0) {
+                alert('交代できるユーザーがキューにいません');
+                return;
+            }
             
-            rotatingUsers.forEach(user => {
+            // 実際に交代するユーザー数を調整
+            const actualRotatingUsers = rotatingUsers.slice(0, availableReplacements);
+            
+            console.log('🔄 Rotating users:', actualRotatingUsers);
+            
+            // パーティーから交代ユーザーを削除
+            actualRotatingUsers.forEach(user => {
                 const index = appState.party.indexOf(user);
                 if (index > -1) {
                     appState.party.splice(index, 1);
                 }
             });
             
-            appState.queue.push(...rotatingUsers);
+            // キューから新しいメンバーを取得
+            const newPartyMembers = appState.queue.splice(0, actualRotatingUsers.length);
             
-            const availableSlots = appState.partySize - appState.party.length;
-            const newPartyMembers = appState.queue.splice(0, availableSlots);
+            // 交代したユーザーをキューの最後に追加
+            appState.queue.push(...actualRotatingUsers);
+            
+            // 新しいメンバーをパーティーに追加
             appState.party.push(...newPartyMembers);
+            
+            // パーティー人数が設定値になるように調整
+            const shortage = appState.partySize - appState.party.length;
+            if (shortage > 0 && appState.queue.length > 0) {
+                const additionalMembers = appState.queue.splice(0, Math.min(shortage, appState.queue.length));
+                appState.party.push(...additionalMembers);
+            }
             
             // Supabaseに保存
             const saved = await saveUsersToSupabase();


### PR DESCRIPTION
## Summary
- 「次へ」ボタンを連打すると全ユーザーが消える問題を修正
- キューが空の場合の適切なハンドリングを追加
- パーティー人数が設定値を維持するよう改善

## Problem
「次へ」ボタンを連打すると以下の問題が発生していました：
- キューが空でも交代処理が実行される
- パーティーから出たユーザーがキューに戻されるが、キューから補充されない
- 結果的にパーティー人数が減少し、最終的に固定ユーザーのみ or 全員消える

## Changes
1. キューが空の場合は交代処理を中止
2. 交代可能人数をキューの人数に基づいて調整
3. 1対1の交代を保証（出る人数 = 入る人数）
4. 交代後もパーティー人数が設定値を維持

## Test plan
- [ ] キューが空の状態で「次へ」をクリックするとエラーメッセージが表示される
- [ ] キューに十分なユーザーがいる場合、正常に交代が行われる
- [ ] 「次へ」を連打してもパーティー人数が維持される
- [ ] 固定ユーザーは交代されない
- [ ] 交代人数設定が正しく反映される

🤖 Generated with [Claude Code](https://claude.ai/code)