### PR TITLE
feat: atomic sync_session_snapshot RPC + DB constraints/indexes; frontend saves via RPC

### DIFF
--- a/database/migrations/20250912_add_constraints_and_indexes.sql
+++ b/database/migrations/20250912_add_constraints_and_indexes.sql
@@ -1,0 +1,38 @@
+-- Ensure uniqueness and performance on session_users
+-- 1) Deduplicate (session_id, user_id) if any accidental duplicates exist
+WITH dups AS (
+  SELECT a.id
+  FROM public.session_users a
+  JOIN public.session_users b
+    ON a.session_id = b.session_id
+   AND a.user_id = b.user_id
+   AND a.id > b.id
+)
+DELETE FROM public.session_users su
+USING dups d
+WHERE su.id = d.id;
+
+-- 2) Normalize order_index per (session_id, position) to be 0..N-1
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY session_id, position ORDER BY order_index, created_at, id) - 1 AS rn
+  FROM public.session_users
+)
+UPDATE public.session_users su
+SET order_index = r.rn
+FROM ranked r
+WHERE su.id = r.id;
+
+-- 3) Add unique constraints and indexes
+ALTER TABLE public.session_users
+  ADD CONSTRAINT uq_session_users_session_user UNIQUE (session_id, user_id);
+
+ALTER TABLE public.session_users
+  ADD CONSTRAINT uq_session_users_order UNIQUE (session_id, position, order_index);
+
+CREATE INDEX IF NOT EXISTS idx_session_users_session_position
+  ON public.session_users (session_id, position);
+
+CREATE INDEX IF NOT EXISTS idx_session_users_session_position_order
+  ON public.session_users (session_id, position, order_index);
+

--- a/database/migrations/20250912_add_sync_session_snapshot_rpc.sql
+++ b/database/migrations/20250912_add_sync_session_snapshot_rpc.sql
@@ -1,0 +1,123 @@
+-- Create RPC to atomically sync party/queue snapshot with UPSERT + delete
+-- Security: SECURITY DEFINER to bypass RLS; restrict search_path
+CREATE OR REPLACE FUNCTION public.sync_session_snapshot(
+  p_session_code text,
+  p_creator_token text,
+  p_party jsonb,
+  p_queue jsonb,
+  p_party_size int DEFAULT NULL,
+  p_rotation_count int DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_session RECORD;
+  v_key BIGINT;
+BEGIN
+  -- Lookup session and validate token
+  SELECT id, party_size, rotation_count, creator_token
+    INTO v_session
+    FROM public.sessions
+   WHERE session_code = p_session_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session not found';
+  END IF;
+
+  IF v_session.creator_token IS NULL OR v_session.creator_token <> p_creator_token THEN
+    RAISE EXCEPTION 'invalid token';
+  END IF;
+
+  v_key := hashtext(p_session_code)::BIGINT;
+  PERFORM pg_advisory_lock(v_key);
+  BEGIN
+    -- Materialize incoming snapshot
+    WITH party_incoming AS (
+      SELECT 
+        COALESCE((rec).user_id, 0)::int AS user_id,
+        COALESCE((rec).name, '')::text AS name,
+        COALESCE((rec).is_fixed, false)::boolean AS is_fixed,
+        ROW_NUMBER() OVER () - 1 AS order_index,
+        'party'::text AS position
+      FROM (
+        SELECT jsonb_to_recordset(COALESCE(p_party, '[]'::jsonb)) AS rec(user_id int, name text, is_fixed boolean)
+      ) t
+    ), queue_incoming AS (
+      SELECT 
+        COALESCE((rec).user_id, 0)::int AS user_id,
+        COALESCE((rec).name, '')::text AS name,
+        false AS is_fixed,
+        ROW_NUMBER() OVER () - 1 AS order_index,
+        'queue'::text AS position
+      FROM (
+        SELECT jsonb_to_recordset(COALESCE(p_queue, '[]'::jsonb)) AS rec(user_id int, name text)
+      ) t
+    ), incoming AS (
+      SELECT * FROM party_incoming
+      UNION ALL
+      SELECT * FROM queue_incoming
+    )
+    -- Upsert
+    INSERT INTO public.session_users (session_id, user_id, name, position, order_index, is_fixed)
+    SELECT v_session.id, i.user_id, i.name, i.position, i.order_index, i.is_fixed
+    FROM incoming i
+    ON CONFLICT (session_id, user_id) DO UPDATE
+      SET name = EXCLUDED.name,
+          position = EXCLUDED.position,
+          order_index = EXCLUDED.order_index,
+          is_fixed = EXCLUDED.is_fixed;
+
+    -- Delete rows not present in incoming
+    DELETE FROM public.session_users su
+    WHERE su.session_id = v_session.id
+      AND NOT EXISTS (
+        SELECT 1 FROM (
+          SELECT user_id FROM (
+            SELECT user_id FROM party_incoming
+            UNION ALL
+            SELECT user_id FROM queue_incoming
+          ) u
+        ) x WHERE x.user_id = su.user_id
+      );
+
+    -- Normalize order_index (party)
+    WITH ranked_party AS (
+      SELECT user_id, ROW_NUMBER() OVER (ORDER BY order_index, created_at, id) - 1 AS rn
+      FROM public.session_users
+      WHERE session_id = v_session.id AND position = 'party'
+    )
+    UPDATE public.session_users su
+       SET order_index = rp.rn
+      FROM ranked_party rp
+     WHERE su.session_id = v_session.id AND su.position = 'party' AND su.user_id = rp.user_id;
+
+    -- Normalize order_index (queue)
+    WITH ranked_queue AS (
+      SELECT user_id, ROW_NUMBER() OVER (ORDER BY order_index, created_at, id) - 1 AS rn
+      FROM public.session_users
+      WHERE session_id = v_session.id AND position = 'queue'
+    )
+    UPDATE public.session_users su
+       SET order_index = rq.rn
+      FROM ranked_queue rq
+     WHERE su.session_id = v_session.id AND su.position = 'queue' AND su.user_id = rq.user_id;
+
+    -- Optionally update session settings
+    IF p_party_size IS NOT NULL OR p_rotation_count IS NOT NULL THEN
+      UPDATE public.sessions s
+         SET party_size = COALESCE(p_party_size, s.party_size),
+             rotation_count = COALESCE(p_rotation_count, s.rotation_count),
+             updated_at = now()
+       WHERE s.id = v_session.id;
+    END IF;
+
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM pg_advisory_unlock(v_key);
+    RAISE;
+  END;
+  PERFORM pg_advisory_unlock(v_key);
+END;
+$$;
+

--- a/public/index.html
+++ b/public/index.html
@@ -1114,7 +1114,7 @@
             }
         }
 
-        // Supabaseにユーザーデータを保存（直列化＋再試行でロスト回避）
+        // Supabaseにユーザーデータを保存（RPCで差分適用＋直列化）
         let isSavingUsers = false;
         let saveQueued = false;
         let currentSavePromise = null;
@@ -1140,57 +1140,48 @@
                 isSavingUsers = true;
                 currentSavePromise = (async () => {
                     try {
-                        console.log('Deleting existing users for session ID:', appState.sessionId);
-                        const { error: deleteError } = await supabase
-                            .from('session_users')
-                            .delete()
-                            .eq('session_id', appState.sessionId);
+                        const partyPayload = appState.party.map((user, index) => ({
+                            user_id: user.id,
+                            name: user.name,
+                            is_fixed: !!user.isFixed,
+                            order_index: index
+                        }));
+                        const queuePayload = appState.queue.map((user, index) => ({
+                            user_id: user.id,
+                            name: user.name,
+                            order_index: index
+                        }));
 
-                        if (deleteError) {
-                            console.error('❌ Error deleting existing users:', deleteError);
-                            // 続行は可能（後続の insert で上書きされるため）
-                        }
+                        console.log('Syncing users via RPC:', {
+                            party_len: partyPayload.length,
+                            queue_len: queuePayload.length
+                        });
 
-                        const allUsers = [
-                            ...appState.party.map((user, index) => ({
-                                session_id: appState.sessionId,
-                                user_id: user.id,
-                                name: user.name,
-                                position: 'party',
-                                order_index: index,
-                                is_fixed: user.isFixed || false
-                            })),
-                            ...appState.queue.map((user, index) => ({
-                                session_id: appState.sessionId,
-                                user_id: user.id,
-                                name: user.name,
-                                position: 'queue',
-                                order_index: index,
-                                is_fixed: false
-                            }))
-                        ];
+                        const { error } = await supabase.rpc('sync_session_snapshot', {
+                            p_session_code: appState.sessionCode,
+                            p_creator_token: appState.creatorToken,
+                            p_party: partyPayload,
+                            p_queue: queuePayload,
+                            p_party_size: null,
+                            p_rotation_count: null
+                        });
 
-                        console.log('Saving users data:', allUsers);
-
-                        if (allUsers.length > 0) {
-                            const { data, error } = await supabase
-                                .from('session_users')
-                                .insert(allUsers);
-
-                            if (error) {
-                                console.error('❌ Error saving users:', error);
-                                alert(`ユーザー保存エラー: ${error.message}`);
-                                return false;
+                        if (error) {
+                            console.error('❌ sync_session_snapshot RPC error:', error);
+                            if (String(error.message || '').includes('invalid token')) {
+                                alert('管理者トークンが無効です。管理者URLからアクセスしてください。');
+                            } else if (String(error.message || '').includes('session not found')) {
+                                alert('セッションが見つかりません');
                             } else {
-                                console.log('✅ Users saved successfully:', data);
-                                return true;
+                                alert(`ユーザー保存エラー: ${error.message}`);
                             }
-                        } else {
-                            console.log('No users to save');
-                            return true;
+                            return false;
                         }
+
+                        console.log('✅ sync_session_snapshot completed');
+                        return true;
                     } catch (error) {
-                        console.error('❌ Exception saving users:', error);
+                        console.error('❌ Exception saving users (RPC):', error);
                         alert(`ユーザー保存例外: ${error.message}`);
                         return false;
                     }
@@ -1583,6 +1574,11 @@
             if (nextBtn) nextBtn.disabled = true;
             
             try {
+                // 直前の保存が進行中であれば完了を待つ（交代と保存の直列化）
+                if (typeof currentSavePromise !== 'undefined' && currentSavePromise) {
+                    console.log('⏳ Waiting for in-flight save before rotation...');
+                    try { await currentSavePromise; } catch (_) {}
+                }
                 if (!supabase || !appState.sessionCode || !appState.creatorToken) {
                     alert('セッション情報が不足しています');
                     return;


### PR DESCRIPTION
## 概要
- 根本対策として、保存の「全削除→全挿入」を廃止し、DB側でトランザクション＋アドバイザリロックのもと差分適用（UPSERT＋削除）するRPCを追加しました。
- 整合性・性能向上のため、`session_users` にユニーク制約と索引を追加しました。
- フロントは保存処理を新RPCに切り替え、交代処理前に保存完了を待つことで競合ウィンドウを縮小しています。

## 変更点
### DB（SQLマイグレーション）
1. `database/migrations/20250912_add_constraints_and_indexes.sql`
   - 重複行の事前除去（(session_id, user_id)）
   - `(session_id, position)` ごとの `order_index` 正規化（0..N-1）
   - ユニーク制約の追加：
     - `uq_session_users_session_user (session_id, user_id)`
     - `uq_session_users_order (session_id, position, order_index)`
   - インデックスの追加：
     - `(session_id, position)`、`(session_id, position, order_index)`

2. `database/migrations/20250912_add_sync_session_snapshot_rpc.sql`
   - 新規関数 `public.sync_session_snapshot(p_session_code, p_creator_token, p_party jsonb, p_queue jsonb, p_party_size int, p_rotation_count int)`
   - SECURITY DEFINER + `search_path='public'`、`pg_advisory_lock(hashtext(session_code))` による直列化
   - party/queue を UPSERT→非該当 DELETE→order_index 正規化→（任意で）設定更新

### フロント
- `public/index.html`
  - `saveUsersToSupabase()` を `supabase.rpc('sync_session_snapshot', {...})` 呼び出しに置換
  - 直列化・合流ロジック（保存キュー）を維持
  - `nextRotation()` 実行前に保存完了を待機して、保存と交代の競合を回避

## ねらい / 背景
- 先行実装では保存中に「次へ」を押すと、RPCが空に近いスナップショットを参照し、見かけ上無反応になるケースがありました。
- 保存をDB側で原子的に差分適用し、交代と同じロックキーで直列化することで、一貫性と体感の安定を向上します。

## 適用手順
1. Supabaseで以下を順に適用
   - `database/migrations/20250912_add_constraints_and_indexes.sql`
   - `database/migrations/20250912_add_sync_session_snapshot_rpc.sql`
2. デプロイ後、動作確認

## 動作確認
- DnD/追加/削除/固定切替/人数変更の直後に「次へ」を押しても無反応にならない
- 重複行が発生しない（(session_id, user_id)）
- 順序が常に 0..N-1 に正規化される
- 交代・保存が同時でも最終状態が一貫（アドバイザリロック）

## リスク/ロールバック
- 既存データに重複がある場合、マイグレーションの重複除去ロジックで解消済み
- 問題時は関数/制約のロールバックと、フロントを旧保存方式に戻すことで復旧可能

